### PR TITLE
fix one-dark color

### DIFF
--- a/one-dark.sh
+++ b/one-dark.sh
@@ -63,7 +63,7 @@ if which "$DCONF" > /dev/null 2>&1; then
 
         # update profile values with theme options
         dset visible-name "'$PROFILE_NAME'"
-        dset palette "['#000000', '#E06C75', '#98c379', '#d19a66', '#61aeee', '#c678dd', '#56b6c2', '#abb2bf', '#5c6370', '#e06c75', '#98c379', '#d19a66', '#62afee', '#c678dd', '#56b6c2', '#ffffff']"
+        dset palette "['#000000', '#e06c75', '#98c379', '#d19a66', '#61afef', '#c678dd', '#56b6c2', '#abb2bf', '#5c6370', '#e06c75', '#98c379', '#d19a66', '#61afef', '#c678dd', '#56b6c2', '#ffffff']"
         dset background-color "'#282c34'"
         dset foreground-color "'#abb2bf'"
         dset bold-color "'#ABB2BF'"
@@ -113,7 +113,7 @@ glist_append() {
 glist_append string /apps/gnome-terminal/global/profile_list "$PROFILE_SLUG"
 
 gset string visible_name "$PROFILE_NAME"
-gset string palette "#000000:#E06C75:#98c379:#d19a66:#61aeee:#c678dd:#56b6c2:#abb2bf:#5c6370:#e06c75:#98c379:#d19a66:#62afee:#c678dd:#56b6c2:#ffffff"
+gset string palette "#000000:#e06c75:#98c379:#d19a66:#61afef:#c678dd:#56b6c2:#abb2bf:#5c6370:#e06c75:#98c379:#d19a66:#61afef:#c678dd:#56b6c2:#ffffff"
 gset string background_color "#282c34"
 gset string foreground_color "#abb2bf"
 gset string bold_color "#abb2bf"


### PR DESCRIPTION
Compaired to this: https://github.com/denysdovhan/one-gnome-terminal/blob/master/COLORS, blue and light blue for one-dark seems wrong, so I fixed.